### PR TITLE
Added --defaults-file to mydumper and myloader

### DIFF
--- a/common.h
+++ b/common.h
@@ -22,6 +22,7 @@ char *username=NULL;
 char *password=NULL;
 char *socket_path=NULL;
 char *db=NULL;
+char *defaults_file=NULL;
 guint port=3306;
 guint num_threads= 4;
 guint verbose=2;
@@ -39,6 +40,7 @@ GOptionEntry common_entries[] =
         { "compress-protocol", 'C', 0, G_OPTION_ARG_NONE, &compress_protocol, "Use compression on the MySQL connection", NULL },
 	{ "version", 'V', 0, G_OPTION_ARG_NONE, &program_version, "Show the program version and exit", NULL },
 	{ "verbose", 'v', 0, G_OPTION_ARG_INT, &verbose, "Verbosity of output, 0 = silent, 1 = errors, 2 = warnings, 3 = info, default 2", NULL },
+	{ "defaults-file", 0, 0, G_OPTION_ARG_FILENAME, &defaults_file, "Use a specific defaults file",  NULL },
         { NULL, 0, 0, G_OPTION_ARG_NONE,   NULL, NULL, NULL }
 };
 

--- a/common.h
+++ b/common.h
@@ -32,15 +32,15 @@ gboolean program_version= FALSE;
 GOptionEntry common_entries[] =
 {
         { "host", 'h', 0, G_OPTION_ARG_STRING, &hostname, "The host to connect to", NULL },
-        { "user", 'u', 0, G_OPTION_ARG_STRING, &username, "Username with privileges to run the dump", NULL },
+        { "user", 'u', 0, G_OPTION_ARG_STRING, &username, "Username with the necessary privileges", NULL },
         { "password", 'p', 0, G_OPTION_ARG_STRING, &password, "User password", NULL },
         { "port", 'P', 0, G_OPTION_ARG_INT, &port, "TCP/IP port to connect to", NULL },
         { "socket", 'S', 0, G_OPTION_ARG_STRING, &socket_path, "UNIX domain socket file to use for connection", NULL },
         { "threads", 't', 0, G_OPTION_ARG_INT, &num_threads, "Number of threads to use, default 4", NULL },
         { "compress-protocol", 'C', 0, G_OPTION_ARG_NONE, &compress_protocol, "Use compression on the MySQL connection", NULL },
-	{ "version", 'V', 0, G_OPTION_ARG_NONE, &program_version, "Show the program version and exit", NULL },
-	{ "verbose", 'v', 0, G_OPTION_ARG_INT, &verbose, "Verbosity of output, 0 = silent, 1 = errors, 2 = warnings, 3 = info, default 2", NULL },
-	{ "defaults-file", 0, 0, G_OPTION_ARG_FILENAME, &defaults_file, "Use a specific defaults file",  NULL },
+        { "version", 'V', 0, G_OPTION_ARG_NONE, &program_version, "Show the program version and exit", NULL },
+        { "verbose", 'v', 0, G_OPTION_ARG_INT, &verbose, "Verbosity of output, 0 = silent, 1 = errors, 2 = warnings, 3 = info, default 2", NULL },
+        { "defaults-file", 0, 0, G_OPTION_ARG_FILENAME, &defaults_file, "Use a specific defaults file",  NULL },
         { NULL, 0, 0, G_OPTION_ARG_NONE,   NULL, NULL, NULL }
 };
 

--- a/docs/mydumper_usage.rst
+++ b/docs/mydumper_usage.rst
@@ -32,6 +32,10 @@ The :program:`mydumper` tool has several available options:
 
    Show help text
 
+.. option:: --defaults-file
+   
+   Use the given option file. If the file does not exist or is otherwise inaccessible, no failure occurs
+
 .. option:: --host, -h
 
    Hostname of MySQL server to connect to (default localhost)

--- a/docs/myloader_usage.rst
+++ b/docs/myloader_usage.rst
@@ -25,6 +25,10 @@ The :program:`myloader` tool has several available options:
 
    Show help text
 
+.. option:: --defaults-file
+
+   Use the given option file. If the file does not exist or is otherwise inaccessible, no failure occurs
+
 .. option:: --host, -h
 
    Hostname of MySQL server to connect to (default localhost)

--- a/mydumper.c
+++ b/mydumper.c
@@ -401,7 +401,9 @@ void *process_queue(struct thread_data *td) {
 	g_mutex_lock(init_mutex);
 	MYSQL *thrconn = mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
-	
+
+    if (defaults_file != NULL)
+    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
 
 	if (compress_protocol)
@@ -602,6 +604,8 @@ void *process_queue_less_locking(struct thread_data *td) {
 	MYSQL *thrconn = mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
 	
+    if (defaults_file != NULL)
+    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
 
 	if (compress_protocol)
@@ -939,6 +943,8 @@ MYSQL *create_main_connection()
 {
 	MYSQL *conn;
 	conn = mysql_init(NULL);
+    if (defaults_file != NULL)
+    	mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(conn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
 
 	if (!mysql_real_connect(conn, hostname, username, password, db, port, socket_path, 0)) {
@@ -1007,6 +1013,8 @@ void *binlog_thread(void *data) {
 	MYSQL_ROW row;
 	MYSQL *conn;
 	conn = mysql_init(NULL);
+    if (defaults_file != NULL)
+    	mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(conn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
 
 	if (!mysql_real_connect(conn, hostname, username, password, db, port, socket_path, 0)) {

--- a/myloader.c
+++ b/myloader.c
@@ -133,6 +133,8 @@ int main(int argc, char *argv[]) {
 
 	MYSQL *conn;
 	conn= mysql_init(NULL);
+    if (defaults_file != NULL)
+    	mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "myloader");
 
 	if (!mysql_real_connect(conn, hostname, username, password, NULL, port, socket_path, 0)) {
@@ -405,6 +407,8 @@ void *process_queue(struct thread_data *td) {
 	MYSQL *thrconn= mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
 
+    if (defaults_file != NULL)
+    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
 	mysql_options(thrconn, MYSQL_READ_DEFAULT_GROUP, "myloader");
 
 	if (compress_protocol)


### PR DESCRIPTION
Added in the `--defaults-file` option to mydumper and myloader, which helps when using a remote backup server that connects to _n_ database servers that require a different configuration