### PR TITLE
make changing trx isolation level a critical error, exit the program …

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -424,11 +424,12 @@ void *process_queue(struct thread_data *td) {
 		g_warning("Failed to increase wait_timeout: %s", mysql_error(thrconn));
 	}
 	if (mysql_query(thrconn, "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")) {
-		g_warning("Failed to set isolation level: %s", mysql_error(thrconn));
+		g_critical("Failed to set isolation level: %s", mysql_error(thrconn));
+		exit(EXIT_FAILURE);
 	}
 	if (mysql_query(thrconn, "START TRANSACTION /*!40108 WITH CONSISTENT SNAPSHOT */")) {
 		g_critical("Failed to start consistent snapshot: %s",mysql_error(thrconn));
-		errors++;
+		exit(EXIT_FAILURE);
 	}
 	if(!skip_tz && mysql_query(thrconn, "/*!40103 SET TIME_ZONE='+00:00' */")){
 		g_critical("Failed to set time zone: %s",mysql_error(thrconn));


### PR DESCRIPTION
If not possible to change to `REPEATABLE-READ`, only a `WARNING` is issued when `WITH CONSISTENT SNAPSHOT` is used.


# `REPEATABLE-READ`

```
session2> set transaction isolation level repeatable read;
Query OK, 0 rows affected (0.00 sec)

session2> start transaction with consistent snapshot;
Query OK, 0 rows affected (0.00 sec)

session2> rollback;
Query OK, 0 rows affected (0.00 sec)
```

This works and a transaction is immediately started.


# `READ-COMMITTED`

```
session2> set transaction isolation level read committed;
Query OK, 0 rows affected (0.00 sec)

session2> start transaction with consistent snapshot;
Query OK, 0 rows affected, 1 warning (0.00 sec)

session2> show warnings;
+---------+------+-------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                 |
+---------+------+-------------------------------------------------------------------------------------------------------------------------+
| Warning |  138 | InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level. |
+---------+------+-------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

session2> rollback;
Query OK, 0 rows affected (0.00 sec)
```

However, this does not work and no consistent snapshot is provided.

# Corresponding Code

When quickly checking the code, there are checks to prevent this:

```
if (mysql_query(thrconn, "SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")) {
	g_warning("Failed to set isolation level: %s", mysql_error(thrconn));
}
if (mysql_query(thrconn, "START TRANSACTION /*!40108 WITH CONSISTENT SNAPSHOT */")) {
	g_critical("Failed to start consistent snapshot: %s",mysql_error(thrconn));
	errors++;
}
```
https://github.com/maxbube/mydumper/blob/9bce1df0938914122665f01ce5b2507da9962a61/mydumper.c#L426-L431

However, this is only a warning message, this should be a critical as this does not guarantee you have a consistent backup

(I'm not sure in which cases you cannot change the isolation level though, but better to prevent it).

Also I added `exit(EXIT_FAILURE)` on both these to avoid continuing to take a backup as it failed to get a consistent backup anyway.