### PR TITLE
correct 'this ‘if’ clause does not guard' error when using make

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -404,9 +404,10 @@ void *process_queue(struct thread_data *td) {
 	MYSQL *thrconn = mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
 
-    if (defaults_file != NULL)
-    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
-	mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+	if (defaults_file != NULL) {
+		mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
+		mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+	}
 
 	if (compress_protocol)
 		mysql_options(thrconn,MYSQL_OPT_COMPRESS,NULL);
@@ -606,10 +607,11 @@ void *process_queue_less_locking(struct thread_data *td) {
 	g_mutex_lock(init_mutex);
 	MYSQL *thrconn = mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
-	
-    if (defaults_file != NULL)
-    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
-	mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+
+	if (defaults_file != NULL) {
+		mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
+		mysql_options(thrconn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+	}
 
 	if (compress_protocol)
 		mysql_options(thrconn,MYSQL_OPT_COMPRESS,NULL);
@@ -946,9 +948,10 @@ MYSQL *create_main_connection()
 {
 	MYSQL *conn;
 	conn = mysql_init(NULL);
-    if (defaults_file != NULL)
-    	mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
-	mysql_options(conn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+	if (defaults_file != NULL) {
+		mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
+		mysql_options(conn,MYSQL_READ_DEFAULT_GROUP,"mydumper");
+	}
 
 	if (!mysql_real_connect(conn, hostname, username, password, db, port, socket_path, 0)) {
 		g_critical("Error connecting to database: %s", mysql_error(conn));

--- a/myloader.c
+++ b/myloader.c
@@ -133,9 +133,10 @@ int main(int argc, char *argv[]) {
 
 	MYSQL *conn;
 	conn= mysql_init(NULL);
-    if (defaults_file != NULL)
-    	mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
-	mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "myloader");
+	if (defaults_file != NULL) {
+		mysql_options(conn,MYSQL_READ_DEFAULT_FILE,defaults_file);
+		mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "myloader");
+	}
 
 	if (!mysql_real_connect(conn, hostname, username, password, NULL, port, socket_path, 0)) {
 		g_critical("Error connection to database: %s", mysql_error(conn));
@@ -407,9 +408,10 @@ void *process_queue(struct thread_data *td) {
 	MYSQL *thrconn= mysql_init(NULL);
 	g_mutex_unlock(init_mutex);
 
-    if (defaults_file != NULL)
-    	mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
-	mysql_options(thrconn, MYSQL_READ_DEFAULT_GROUP, "myloader");
+	if (defaults_file != NULL) {
+		mysql_options(thrconn,MYSQL_READ_DEFAULT_FILE,defaults_file);
+		mysql_options(thrconn, MYSQL_READ_DEFAULT_GROUP, "myloader");
+	}
 
 	if (compress_protocol)
 		mysql_options(thrconn, MYSQL_OPT_COMPRESS, NULL);


### PR DESCRIPTION
When attempting to build on Fedora 24 using

make install
make

The following errors would be displayed:
```
mydumper.c: In function ‘process_queue’:
mydumper.c:407:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if (defaults_file != NULL)
     ^~
mydumper.c:409:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
```

This commit resolves all instances of this error, and allows the build to complete.