### PR TITLE
Add basic timing message per table restore

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -445,7 +445,13 @@ void *process_queue(struct thread_data *td) {
 			case JOB_RESTORE:
 				rj= (struct restore_job *)job->job_data;
 				g_message("Thread %d restoring `%s`.`%s` part %d", td->thread_id, rj->database, rj->table, rj->part);
+
+				GTimer * timer = g_timer_new();
 				restore_data(thrconn, rj->database, rj->table, rj->filename, FALSE, TRUE);
+				gdouble elapsed = g_timer_elapsed(timer, NULL);
+				g_timer_destroy(timer);
+				g_message("Table %s.%s (Thread %d) took %f seconds", rj->database, rj->table, td->thread_id, elapsed);
+
 				if (rj->database) g_free(rj->database);
 				if (rj->table) g_free(rj->table);
 				if (rj->filename) g_free(rj->filename);


### PR DESCRIPTION
This is a proof of concept for a modification I'd like to make. I'd like to get feedback on changes you would want to see made -- would you prefer this being a option to the loader, using a different timing method, is this a change you even want to support or is it fine as is?

I appreciate your time and the effort you put into this tool.