### PR TITLE
Redefine MYSQL_SERVER_VERSION with the client version

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -22,6 +22,11 @@
 #define _FILE_OFFSET_BITS 64
 
 #include <mysql.h>
+
+#if defined MARIADB_CLIENT_VERSION_STR && !defined MYSQL_SERVER_VERSION
+	#define MYSQL_SERVER_VERSION MARIADB_CLIENT_VERSION_STR
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>

--- a/myloader.c
+++ b/myloader.c
@@ -19,6 +19,11 @@
 #define _FILE_OFFSET_BITS 64
 
 #include <mysql.h>
+
+#if defined MARIADB_CLIENT_VERSION_STR && !defined MYSQL_SERVER_VERSION
+	#define MYSQL_SERVER_VERSION MARIADB_CLIENT_VERSION_STR
+#endif
+
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
MariaDB 10.2 splitted server/client variables and now
MYSQL_SERVER_VERSION is not available. We now take the
version string from the client header.

Patch provided by by Brian Evans (grknight@gentoo.org):
https://bugs.gentoo.org/635176

Upstream issue:
https://jira.mariadb.org/browse/MDEV-13773