### PR TITLE
Fix compilation with older MySQL versions.

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -53,6 +53,11 @@ const char BINLOG_DIRECTORY[]= "binlog_snapshot";
 const char DAEMON_BINLOGS[]= "binlogs";
 #endif
 
+/* Some earlier versions of MySQL do not yet define MYSQL_TYPE_JSON */
+#ifndef MYSQL_TYPE_JSON
+#define MYSQL_TYPE_JSON 245
+#endif
+
 static GMutex * init_mutex = NULL;
 
 /* Program options */


### PR DESCRIPTION
Commit 37aa06686dc9ca97abbb335f8bd4b354a9694d7c broke compilation under
at least Debian 9 and CentOS 6, as MYSQL_TYPE_JSON is not defined in the
MySQL versions they ship.