### PR TITLE
Allow skipping a very large number of tables

### DIFF
--- a/docs/mydumper_usage.rst
+++ b/docs/mydumper_usage.rst
@@ -105,6 +105,11 @@ The :program:`mydumper` tool has several available options:
 
    A regular expression to match against database and table
 
+.. option:: --omit-from-file, -O
+
+   File containing a list of database.table entries to skip, one per line; the
+   skipped entries have precedence over patterns specified by the regex option
+
 .. option:: --ignore-engines, -i
 
    Comma separated list of storage engines to ignore


### PR DESCRIPTION
As a followup to issue #77 here is a patch to allow mydumper to be fed a file containing a list of tables to skip during the dump.  It has been tested and works under Debian 9 and CentOS 6; I don't have the means to test on other platforms but AFAIK there is no usage of specific GNU/Linux constructs.