### PR TITLE
Fix issue #135

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1370,8 +1370,13 @@ void start_dump(MYSQL *conn)
 		mysql_query(conn, "CREATE TABLE IF NOT EXISTS mysql.tokudbdummy (a INT) ENGINE=TokuDB");
 		need_dummy_toku_read=1;
 	}
-	
-	mysql_query(conn, "START TRANSACTION /*!40108 WITH CONSISTENT SNAPSHOT */");
+
+	// Do not start a transaction when lock all tables instead of FTWRL,
+	// since it can implicitly release read locks we hold
+	if (!lock_all_tables) {
+		mysql_query(conn, "START TRANSACTION /*!40108 WITH CONSISTENT SNAPSHOT */");
+	}
+
 	if (need_dummy_read) {
 		mysql_query(conn,"SELECT /*!40001 SQL_NO_CACHE */ * FROM mysql.mydumperdummy");
 		MYSQL_RES *res=mysql_store_result(conn);


### PR DESCRIPTION
a small fix to issue #135 
when enable --lock-all-tables, do not start transaction before we get snapshot info