### PR TITLE
Memleak fixes + Improvements

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -2849,7 +2849,7 @@ void dump_table(MYSQL *conn, char *database, char *table, struct configuration *
 
 	if (chunks) {
 		int nchunk=0;
-		for (chunks = g_list_first(chunks); chunks; chunks=g_list_next(chunks)) {
+		for (GList *iter = chunks; iter != NULL; iter = iter->next) {
 			struct job *j = g_new0(struct job,1);
 			struct table_job *tj = g_new0(struct table_job,1);
 			j->job_data=(void*) tj;
@@ -2861,7 +2861,7 @@ void dump_table(MYSQL *conn, char *database, char *table, struct configuration *
 				tj->filename=g_strdup_printf("%s/%d/%s.%s.%05d.sql%s", output_directory, dump_number, database, table, nchunk,(compress_output?".gz":""));
 			else
 				tj->filename=g_strdup_printf("%s/%s.%s.%05d.sql%s", output_directory, database, table, nchunk,(compress_output?".gz":""));
-			tj->where=(char *)chunks->data;
+			tj->where=(char *)iter->data;
 			if (!is_innodb && nchunk)
                                 g_atomic_int_inc(&non_innodb_table_counter);
 			g_async_queue_push(conf->queue,j);

--- a/mydumper.c
+++ b/mydumper.c
@@ -2756,7 +2756,7 @@ void dump_view_data(MYSQL *conn, char *database, char *table, char *filename, ch
 }
 
 void dump_table_data_file(MYSQL *conn, char *database, char *table, char *where, char *filename) {
-	void *outfile;
+	void *outfile = NULL;
 
 	if (!compress_output)
 		outfile = g_fopen(filename, "w");
@@ -3177,11 +3177,13 @@ cleanup:
 	if (result) {
 		mysql_free_result(result);
 	}
-	
-	if (!compress_output){
-		fclose((FILE *)file);
-	} else {
-		gzclose((gzFile)file);
+
+	if (file) {
+		if (!compress_output) {
+			fclose((FILE *)file);
+		} else {
+			gzclose((gzFile)file);
+		}
 	}
 	
 	if (!st_in_file && !build_empty_files) {

--- a/mydumper.c
+++ b/mydumper.c
@@ -1522,7 +1522,8 @@ void start_dump(MYSQL *conn)
 	non_innodb_table= g_list_reverse(non_innodb_table);
 	if (less_locking) {
 
-		for (GList *iter = non_innodb_table; iter != NULL; iter = iter->next) {
+		GList *iter;
+		for (iter = non_innodb_table; iter != NULL; iter = iter->next) {
 			dbt= (struct db_table*) iter->data;
 			tn = 0;
 			min = nits[0];
@@ -1557,7 +1558,8 @@ void start_dump(MYSQL *conn)
 			g_async_queue_push(conf.queue_less_locking,j);
 		}
 	}else{
-		for (GList *iter = non_innodb_table; iter != NULL; iter = iter->next) {
+		GList *iter;
+		for (iter = non_innodb_table; iter != NULL; iter = iter->next) {
 			dbt= (struct db_table*) iter->data;
 			dump_table(conn, dbt->database, dbt->table, &conf, FALSE);
 			g_atomic_int_inc(&non_innodb_table_counter);
@@ -1567,14 +1569,15 @@ void start_dump(MYSQL *conn)
 	}
 	
 	innodb_tables = g_list_reverse(innodb_tables);
-	for (GList *iter = innodb_tables; iter != NULL; iter = iter->next) {
+	GList *iter;
+	for (iter = innodb_tables; iter != NULL; iter = iter->next) {
 		dbt= (struct db_table*) iter->data;
 		dump_table(conn, dbt->database, dbt->table, &conf, TRUE);
 	}
 	g_list_free(innodb_tables);
 
 	table_schemas = g_list_reverse(table_schemas);
-	for (GList *iter = table_schemas; iter != NULL; iter = iter->next) {
+	for (iter = table_schemas; iter != NULL; iter = iter->next) {
 		dbt= (struct db_table*) iter->data;
 		dump_schema(conn, dbt->database, dbt->table, &conf);
 		g_free(dbt->table);
@@ -1584,7 +1587,7 @@ void start_dump(MYSQL *conn)
 	g_list_free(table_schemas);
 
 	view_schemas = g_list_reverse(view_schemas);
-	for (GList *iter = view_schemas; iter != NULL; iter = iter->next) {
+	for (iter = view_schemas; iter != NULL; iter = iter->next) {
 		dbt= (struct db_table*) iter->data;
 		dump_view(dbt->database, dbt->table, &conf);
 		g_free(dbt->table);
@@ -1594,7 +1597,7 @@ void start_dump(MYSQL *conn)
 	g_list_free(view_schemas);
 
 	schema_post = g_list_reverse(schema_post);
-	for (GList *iter = schema_post; iter != NULL; iter = iter->next) {
+	for (iter = schema_post; iter != NULL; iter = iter->next) {
 		sp= (struct schema_post*) iter->data;
 		dump_schema_post(sp->database, &conf);
 		g_free(sp->database);
@@ -2106,7 +2109,8 @@ void dump_database_thread(MYSQL * conn, char *database) {
 
 		/* Check if the table was recently updated */
 		if(no_updated_tables && !is_view){
-			for (GList *iter = no_updated_tables; iter != NULL; iter = iter->next) {
+			GList *iter;
+			for (iter = no_updated_tables; iter != NULL; iter = iter->next) {
 				if(g_ascii_strcasecmp (iter->data, g_strdup_printf("%s.%s", database, row[0])) == 0){
 					g_message("NO UPDATED TABLE: %s.%s", database, row[0]);
 					dump=0;
@@ -2860,7 +2864,8 @@ void dump_table(MYSQL *conn, char *database, char *table, struct configuration *
 
 	if (chunks) {
 		int nchunk=0;
-		for (GList *iter = chunks; iter != NULL; iter = iter->next) {
+		GList *iter;
+		for (iter = chunks; iter != NULL; iter = iter->next) {
 			struct job *j = g_new0(struct job,1);
 			struct table_job *tj = g_new0(struct table_job,1);
 			j->job_data=(void*) tj;
@@ -2906,7 +2911,8 @@ void dump_tables(MYSQL *conn, GList *noninnodb_tables_list, struct configuration
 	j->type=JOB_LOCK_DUMP_NON_INNODB;
 	j->job_data=(void*) tjs;
 
-	for (GList *iter = noninnodb_tables_list; iter != NULL; iter = iter->next) {
+	GList *iter;
+	for (iter = noninnodb_tables_list; iter != NULL; iter = iter->next) {
 		dbt = (struct db_table*) iter->data;
 
 		if (rows_per_file)
@@ -2914,7 +2920,8 @@ void dump_tables(MYSQL *conn, GList *noninnodb_tables_list, struct configuration
 
 		if(chunks){
 			int nchunk=0;
-			for (GList *citer = chunks; citer != NULL; citer = citer->next) {
+			GList *citer;
+			for (citer = chunks; citer != NULL; citer = citer->next) {
 				struct table_job *tj = g_new0(struct table_job,1);
 				tj->database = g_strdup_printf("%s",dbt->database);
 				tj->table = g_strdup_printf("%s",dbt->table);

--- a/mydumper.c
+++ b/mydumper.c
@@ -2999,7 +2999,6 @@ guint64 dump_table_data(MYSQL * conn, FILE *file, char *database, char *table, c
 			g_critical("Error dumping table (%s.%s) data: %s ",database, table, mysql_error(conn));
 			errors++;
 		}
-		g_free(query);
 		goto cleanup;
 	}
 

--- a/mydumper.h
+++ b/mydumper.h
@@ -22,7 +22,7 @@
 #ifndef _mydumper_h
 #define _mydumper_h
 
-enum job_type { JOB_SHUTDOWN, JOB_RESTORE, JOB_DUMP, JOB_DUMP_NON_INNODB, JOB_SCHEMA, JOB_VIEW, JOB_TRIGGERS, JOB_SCHEMA_POST, JOB_BINLOG, JOB_LOCK_DUMP_NON_INNODB, JOB_CREATE_DATABASE };
+enum job_type { JOB_SHUTDOWN, JOB_RESTORE, JOB_DUMP, JOB_DUMP_NON_INNODB, JOB_SCHEMA, JOB_VIEW, JOB_TRIGGERS, JOB_SCHEMA_POST, JOB_BINLOG, JOB_LOCK_DUMP_NON_INNODB, JOB_CREATE_DATABASE, JOB_DUMP_DATABASE };
 
 struct configuration {
 	char use_any_index;
@@ -30,6 +30,7 @@ struct configuration {
 	GAsyncQueue* queue_less_locking;
 	GAsyncQueue* ready;
 	GAsyncQueue* ready_less_locking;
+	GAsyncQueue* ready_database_dump;
 	GAsyncQueue* unlock_tables;
 	GMutex* mutex;
 	int done;
@@ -55,6 +56,10 @@ struct table_job {
 
 struct tables_job {
 	GList* table_job_list;
+};
+
+struct dump_database_job {
+	char *database;
 };
 
 struct create_database_job {

--- a/mydumper.h
+++ b/mydumper.h
@@ -22,7 +22,7 @@
 #ifndef _mydumper_h
 #define _mydumper_h
 
-enum job_type { JOB_SHUTDOWN, JOB_RESTORE, JOB_DUMP, JOB_DUMP_NON_INNODB, JOB_SCHEMA, JOB_VIEW, JOB_TRIGGERS, JOB_SCHEMA_POST, JOB_BINLOG, JOB_LOCK_DUMP_NON_INNODB };
+enum job_type { JOB_SHUTDOWN, JOB_RESTORE, JOB_DUMP, JOB_DUMP_NON_INNODB, JOB_SCHEMA, JOB_VIEW, JOB_TRIGGERS, JOB_SCHEMA_POST, JOB_BINLOG, JOB_LOCK_DUMP_NON_INNODB, JOB_CREATE_DATABASE };
 
 struct configuration {
 	char use_any_index;
@@ -55,6 +55,11 @@ struct table_job {
 
 struct tables_job {
 	GList* table_job_list;
+};
+
+struct create_database_job {
+	char *database;
+	char *filename;
 };
 
 struct schema_job {


### PR DESCRIPTION
Hi,

I did some changes in the code to first of all fix a lot of memleaks that were in the code.
Normally all of them should be resolved :)

Next to that I also moved the listing of all tables into the threads, cause with a lot of databases/tables, this is a huge slowdown!
On a database with ~500 databases I went from 20 minutes to take the dump to 8 minutes!

A final fix is also to replace g_list_append everywhere with g_list_prepend and a g_list_reverse.
See the issue for more information.