### PR TITLE
PS8 skip backup locks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(mydumper)
-set(VERSION 0.9.5)
+set(VERSION 0.10.0)
 set(ARCHIVE_NAME "${CMAKE_PROJECT_NAME}-${VERSION}")
 
 #Required packages


### PR DESCRIPTION
Percona Server 8 removed LOCK BINLOG so backup locks is useless for mydumper now and we need to fail back to FTWRL.

In future code we could avoid it using snapshot cloning if
 - no slave configured 
 - no GTID

