### PR TITLE
Dump strings using single quote instead of double quotes

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -2203,7 +2203,7 @@ GList *get_chunks_for_table(MYSQL *conn, char *database, char *table,
   char *max = row[1];
 
   /* Got total number of rows, skip chunk logic if estimates are low */
-  guint64 rows = estimate_count(conn, database, table, field, NULL, NULL);
+  guint64 rows = estimate_count(conn, database, table, field, min, max);
   if (rows <= rows_per_file)
     goto cleanup;
 
@@ -2267,16 +2267,16 @@ guint64 estimate_count(MYSQL *conn, char *database, char *table, char *field,
     if (from) {
       escaped = g_new(char, strlen(from) * 2 + 1);
       mysql_real_escape_string(conn, escaped, from, strlen(from));
-      fromclause = g_strdup_printf(" `%s` >= '%s' ", field, escaped);
+      fromclause = g_strdup_printf(" `%s` >= %s ", field, escaped);
       g_free(escaped);
     }
     if (to) {
       escaped = g_new(char, strlen(to) * 2 + 1);
-      mysql_real_escape_string(conn, escaped, from, strlen(from));
-      toclause = g_strdup_printf(" `%s` <= '%s'", field, escaped);
+      mysql_real_escape_string(conn, escaped, to, strlen(to));
+      toclause = g_strdup_printf(" `%s` <= %s", field, escaped);
       g_free(escaped);
     }
-    query = g_strdup_printf("%s WHERE `%s` %s %s", querybase,
+    query = g_strdup_printf("%s WHERE %s %s %s", querybase,
                             (from ? fromclause : ""),
                             ((from && to) ? "AND" : ""), (to ? toclause : ""));
 

--- a/mydumper.c
+++ b/mydumper.c
@@ -2267,13 +2267,13 @@ guint64 estimate_count(MYSQL *conn, char *database, char *table, char *field,
     if (from) {
       escaped = g_new(char, strlen(from) * 2 + 1);
       mysql_real_escape_string(conn, escaped, from, strlen(from));
-      fromclause = g_strdup_printf(" `%s` >= \"%s\" ", field, escaped);
+      fromclause = g_strdup_printf(" `%s` >= '%s' ", field, escaped);
       g_free(escaped);
     }
     if (to) {
       escaped = g_new(char, strlen(to) * 2 + 1);
       mysql_real_escape_string(conn, escaped, from, strlen(from));
-      toclause = g_strdup_printf(" `%s` <= \"%s\"", field, escaped);
+      toclause = g_strdup_printf(" `%s` <= '%s'", field, escaped);
       g_free(escaped);
     }
     query = g_strdup_printf("%s WHERE `%s` %s %s", querybase,
@@ -3554,9 +3554,9 @@ guint64 dump_table_data(MYSQL *conn, FILE *file, char *database, char *table,
         mysql_real_escape_string(conn, escaped->str, row[i], lengths[i]);
         if (fields[i].type == MYSQL_TYPE_JSON)
           g_string_append(statement_row, "CONVERT(");
-        g_string_append_c(statement_row, '\"');
+        g_string_append_c(statement_row, '\'');
         g_string_append(statement_row, escaped->str);
-        g_string_append_c(statement_row, '\"');
+        g_string_append_c(statement_row, '\'');
         if (fields[i].type == MYSQL_TYPE_JSON)
           g_string_append(statement_row, " USING UTF8MB4)");
       }


### PR DESCRIPTION
Single quote strings work in both ANSI_QUOTES turned on and off, while double quote only works when ANSI_QUOTES is turned off. If the upstream server has ANSI_QUOTES turned on, the SHOW CREATE TABLE output would use double quotes for identifiers, causing the produced *.sql files impossible to load in any ANSI_QUOTES mode.