### PR TITLE
Add --insert-ignore flag to documentation

### DIFF
--- a/docs/mydumper_usage.rst
+++ b/docs/mydumper_usage.rst
@@ -114,6 +114,10 @@ The :program:`mydumper` tool has several available options:
 
    Comma separated list of storage engines to ignore
 
+.. option:: --insert-ignore, -N
+
+   Dump rows with INSERT IGNORE INTO instead of INSERT INTO
+
 .. option:: --no-schemas, -m
 
    Do not dump schemas with the data


### PR DESCRIPTION
Didn't find it in the documentation, only in the source code. Didn't actually test it's behavior, but I assume it's working.

Source: https://github.com/maxbube/mydumper/blob/2cdd78599ea7e13f36c6e8a09051814f6bd1564a/mydumper.c#L177-L178