### PR TITLE
Add quoting to column names when generating string for SELECT

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -2112,7 +2112,9 @@ GString *get_insertable_fields(MYSQL *conn, char *database, char *table) {
       g_string_append(field_list, ",");
     }
 
-    g_string_append(field_list, row[0]);
+    gchar *tb = g_strdup_printf("`%s`", row[0]);
+    g_string_append(field_list, tb);
+    g_free(tb);
   }
   mysql_free_result(res);
 


### PR DESCRIPTION
get_insertable_fields() is missing quoting of the column names when generating the string of column names to return.

Fixes issue #215 