### PR TITLE
Refactor logging and enable --logfile in myloader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,14 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_SOURCE_DI
 
 
 if (WITH_BINLOG)
-
-  add_executable(mydumper mydumper.c binlog.c server_detect.c g_unix_signal.c connection.c getPassword.c)
+  add_executable(mydumper mydumper.c binlog.c server_detect.c g_unix_signal.c connection.c getPassword.c logging.c set_verbose.c)
 else (WITH_BINLOG)
-  add_executable(mydumper mydumper.c server_detect.c g_unix_signal.c connection.c getPassword.c)
+  add_executable(mydumper mydumper.c server_detect.c g_unix_signal.c connection.c getPassword.c logging.c set_verbose.c)
 endif (WITH_BINLOG)
 target_link_libraries(mydumper ${MYSQL_LIBRARIES} ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES} ${PCRE_PCRE_LIBRARY} ${ZLIB_LIBRARIES} stdc++)
 
 
-add_executable(myloader myloader.c connection.c getPassword.c)
+add_executable(myloader myloader.c connection.c getPassword.c logging.c set_verbose.c)
 target_link_libraries(myloader ${MYSQL_LIBRARIES} ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES} ${PCRE_PCRE_LIBRARY} ${ZLIB_LIBRARIES} stdc++)
 
 INSTALL(TARGETS mydumper myloader

--- a/binlog.c
+++ b/binlog.c
@@ -29,6 +29,7 @@
 #include <zlib.h>
 #include "mydumper.h"
 #include "binlog.h"
+#include "set_verbose.h"
 
 #define BINLOG_MAGIC "\xfe\x62\x69\x6e"
 

--- a/logging.c
+++ b/logging.c
@@ -1,0 +1,77 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+        Authors:        Domas Mituzas, Facebook ( domas at fb dot com )
+                        Mark Leith, Oracle Corporation (mark dot leith at oracle
+   dot com) Andrew Hutchings, SkySQL (andrew at skysql dot com)
+
+*/
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <glib.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <time.h>
+#include <zlib.h>
+#include <pcre.h>
+#include <signal.h>
+#include <glib/gstdio.h>
+
+gchar *logfile;
+FILE *logoutfile;
+
+void no_log(const gchar *log_domain, GLogLevelFlags log_level,
+            const gchar *message, gpointer user_data) {
+  (void)log_domain;
+  (void)log_level;
+  (void)message;
+  (void)user_data;
+}
+
+void write_log_file(const gchar *log_domain, GLogLevelFlags log_level,
+                    const gchar *message, gpointer user_data) {
+  (void)log_domain;
+  (void)user_data;
+
+  gchar date[20];
+  time_t rawtime;
+  struct tm timeinfo;
+
+  time(&rawtime);
+  localtime_r(&rawtime, &timeinfo);
+  strftime(date, 20, "%Y-%m-%d %H:%M:%S", &timeinfo);
+
+  GString *message_out = g_string_new(date);
+  if (log_level & G_LOG_LEVEL_DEBUG) {
+    g_string_append(message_out, " [DEBUG] - ");
+  } else if ((log_level & G_LOG_LEVEL_INFO) ||
+             (log_level & G_LOG_LEVEL_MESSAGE)) {
+    g_string_append(message_out, " [INFO] - ");
+  } else if (log_level & G_LOG_LEVEL_WARNING) {
+    g_string_append(message_out, " [WARNING] - ");
+  } else if ((log_level & G_LOG_LEVEL_ERROR) ||
+             (log_level & G_LOG_LEVEL_CRITICAL)) {
+    g_string_append(message_out, " [ERROR] - ");
+  }
+
+  g_string_append_printf(message_out, "%s\n", message);
+  if (write(fileno(logoutfile), message_out->str, message_out->len) <= 0) {
+    fprintf(stderr, "Cannot write to log file with error %d.  Exiting...",
+            errno);
+  }
+  g_string_free(message_out, TRUE);
+}

--- a/logging.h
+++ b/logging.h
@@ -1,0 +1,35 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+        Authors:        Domas Mituzas, Facebook ( domas at fb dot com )
+                        Mark Leith, Oracle Corporation (mark dot leith at oracle
+   dot com) Andrew Hutchings, SkySQL (andrew at skysql dot com)
+
+*/
+
+#ifndef LOGGING_H
+#define LOGGING_H
+
+// variables
+extern gchar *logfile;
+extern FILE *logoutfile;
+
+// functions
+void no_log(const gchar *log_domain, GLogLevelFlags log_level,
+            const gchar *message, gpointer user_data);
+
+void write_log_file(const gchar *log_domain, GLogLevelFlags log_level,
+                    const gchar *message, gpointer user_data);
+
+#endif

--- a/mydumper.c
+++ b/mydumper.c
@@ -273,8 +273,6 @@ gboolean check_regex(char *database, char *table);
 gboolean check_skiplist(char *database, char *table);
 int tables_skiplist_cmp(gconstpointer a, gconstpointer b, gpointer user_data);
 void read_tables_skiplist(const gchar *filename);
-void no_log(const gchar *log_domain, GLogLevelFlags log_level,
-            const gchar *message, gpointer user_data);
 #ifdef WITH_BINLOG
 MYSQL *reconnect_for_binlog(MYSQL *thrconn);
 void *binlog_thread(void *data);

--- a/mydumper.c
+++ b/mydumper.c
@@ -51,6 +51,8 @@
 #include "g_unix_signal.h"
 #include <math.h>
 #include "getPassword.h"
+#include "logging.h"
+#include "set_verbose.h"
 
 char *regexstring = NULL;
 
@@ -100,9 +102,6 @@ gboolean need_binlogs = FALSE;
 gchar *binlog_directory = NULL;
 gchar *daemon_binlog_directory = NULL;
 #endif
-
-gchar *logfile = NULL;
-FILE *logoutfile = NULL;
 
 gboolean no_schemas = FALSE;
 gboolean no_data = FALSE;
@@ -276,7 +275,6 @@ int tables_skiplist_cmp(gconstpointer a, gconstpointer b, gpointer user_data);
 void read_tables_skiplist(const gchar *filename);
 void no_log(const gchar *log_domain, GLogLevelFlags log_level,
             const gchar *message, gpointer user_data);
-void set_verbose(guint verbosity);
 #ifdef WITH_BINLOG
 MYSQL *reconnect_for_binlog(MYSQL *thrconn);
 void *binlog_thread(void *data);
@@ -286,56 +284,6 @@ MYSQL *create_main_connection();
 void *exec_thread(void *data);
 void write_log_file(const gchar *log_domain, GLogLevelFlags log_level,
                     const gchar *message, gpointer user_data);
-
-void no_log(const gchar *log_domain, GLogLevelFlags log_level,
-            const gchar *message, gpointer user_data) {
-  (void)log_domain;
-  (void)log_level;
-  (void)message;
-  (void)user_data;
-}
-
-void set_verbose(guint verbosity) {
-  if (logfile) {
-    logoutfile = g_fopen(logfile, "w");
-    if (!logoutfile) {
-      g_critical("Could not open log file '%s' for writing: %d", logfile,
-                 errno);
-      exit(EXIT_FAILURE);
-    }
-  }
-
-  switch (verbosity) {
-  case 0:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK), no_log, NULL);
-    break;
-  case 1:
-    g_log_set_handler(
-        NULL, (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE),
-        no_log, NULL);
-    if (logfile)
-      g_log_set_handler(
-          NULL, (GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL),
-          write_log_file, NULL);
-    break;
-  case 2:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MESSAGE), no_log,
-                      NULL);
-    if (logfile)
-      g_log_set_handler(
-          NULL,
-          (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
-                           G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
-                           G_LOG_LEVEL_CRITICAL),
-          write_log_file, NULL);
-    break;
-  default:
-    if (logfile)
-      g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK),
-                        write_log_file, NULL);
-    break;
-  }
-}
 
 gboolean sig_triggered(gpointer user_data) {
   (void)user_data;
@@ -3710,38 +3658,4 @@ gboolean write_data(FILE *file, GString *data) {
   }
 
   return TRUE;
-}
-
-void write_log_file(const gchar *log_domain, GLogLevelFlags log_level,
-                    const gchar *message, gpointer user_data) {
-  (void)log_domain;
-  (void)user_data;
-
-  gchar date[20];
-  time_t rawtime;
-  struct tm timeinfo;
-
-  time(&rawtime);
-  localtime_r(&rawtime, &timeinfo);
-  strftime(date, 20, "%Y-%m-%d %H:%M:%S", &timeinfo);
-
-  GString *message_out = g_string_new(date);
-  if (log_level & G_LOG_LEVEL_DEBUG) {
-    g_string_append(message_out, " [DEBUG] - ");
-  } else if ((log_level & G_LOG_LEVEL_INFO) ||
-             (log_level & G_LOG_LEVEL_MESSAGE)) {
-    g_string_append(message_out, " [INFO] - ");
-  } else if (log_level & G_LOG_LEVEL_WARNING) {
-    g_string_append(message_out, " [WARNING] - ");
-  } else if ((log_level & G_LOG_LEVEL_ERROR) ||
-             (log_level & G_LOG_LEVEL_CRITICAL)) {
-    g_string_append(message_out, " [ERROR] - ");
-  }
-
-  g_string_append_printf(message_out, "%s\n", message);
-  if (write(fileno(logoutfile), message_out->str, message_out->len) <= 0) {
-    fprintf(stderr, "Cannot write to log file with error %d.  Exiting...",
-            errno);
-  }
-  g_string_free(message_out, TRUE);
 }

--- a/myloader.c
+++ b/myloader.c
@@ -192,6 +192,10 @@ int main(int argc, char *argv[]) {
   g_free(td);
   g_free(threads);
 
+  if (logoutfile) {
+    fclose(logoutfile);
+  }
+
   return errors ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 

--- a/myloader.c
+++ b/myloader.c
@@ -38,6 +38,8 @@
 #include "connection.h"
 #include "config.h"
 #include "getPassword.h"
+#include "logging.h"
+#include "set_verbose.h"
 
 guint commit_count = 1000;
 gchar *directory = NULL;
@@ -61,7 +63,6 @@ void restore_schema_triggers(MYSQL *conn);
 void restore_schema_post(MYSQL *conn);
 void no_log(const gchar *log_domain, GLogLevelFlags log_level,
             const gchar *message, gpointer user_data);
-void set_verbose(guint verbosity);
 void create_database(MYSQL *conn, gchar *database);
 
 static GOptionEntry entries[] = {
@@ -77,34 +78,9 @@ static GOptionEntry entries[] = {
      "Database to restore", NULL},
     {"enable-binlog", 'e', 0, G_OPTION_ARG_NONE, &enable_binlog,
      "Enable binary logging of the restore data", NULL},
+    {"logfile", 'L', 0, G_OPTION_ARG_FILENAME, &logfile,
+     "Log file name to use, by default stdout is used", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
-
-void no_log(const gchar *log_domain, GLogLevelFlags log_level,
-            const gchar *message, gpointer user_data) {
-  (void)log_domain;
-  (void)log_level;
-  (void)message;
-  (void)user_data;
-}
-
-void set_verbose(guint verbosity) {
-  switch (verbosity) {
-  case 0:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK), no_log, NULL);
-    break;
-  case 1:
-    g_log_set_handler(
-        NULL, (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE),
-        no_log, NULL);
-    break;
-  case 2:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MESSAGE), no_log,
-                      NULL);
-    break;
-  default:
-    break;
-  }
-}
 
 int main(int argc, char *argv[]) {
   struct configuration conf = {NULL, NULL, NULL, 0};

--- a/set_verbose.c
+++ b/set_verbose.c
@@ -1,0 +1,76 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+        Authors:        Domas Mituzas, Facebook ( domas at fb dot com )
+                        Mark Leith, Oracle Corporation (mark dot leith at oracle
+   dot com) Andrew Hutchings, SkySQL (andrew at skysql dot com)
+
+*/
+
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <glib.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <time.h>
+#include <zlib.h>
+#include <pcre.h>
+#include <signal.h>
+#include <glib/gstdio.h>
+
+#include "logging.h"
+
+void set_verbose(guint verbosity) {
+  if (logfile) {
+    logoutfile = g_fopen(logfile, "w");
+    if (!logoutfile) {
+      g_critical("Could not open log file '%s' for writing: %d", logfile,
+                 errno);
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  switch (verbosity) {
+  case 0:
+    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK), no_log, NULL);
+    break;
+  case 1:
+    g_log_set_handler(
+        NULL, (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE),
+        no_log, NULL);
+    if (logfile)
+      g_log_set_handler(
+          NULL, (GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL),
+          write_log_file, NULL);
+    break;
+  case 2:
+    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MESSAGE), no_log,
+                      NULL);
+    if (logfile)
+      g_log_set_handler(
+          NULL,
+          (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
+                           G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
+                           G_LOG_LEVEL_CRITICAL),
+          write_log_file, NULL);
+    break;
+  default:
+    if (logfile)
+      g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK),
+                        write_log_file, NULL);
+    break;
+  }
+}

--- a/set_verbose.h
+++ b/set_verbose.h
@@ -1,0 +1,26 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+        Authors:        Domas Mituzas, Facebook ( domas at fb dot com )
+                        Mark Leith, Oracle Corporation (mark dot leith at oracle
+   dot com) Andrew Hutchings, SkySQL (andrew at skysql dot com)
+
+*/
+
+#ifndef SET_VERBOSE_H
+#define SET_VERBOSE_H
+
+void set_verbose(guint verbosity);
+
+#endif


### PR DESCRIPTION
Refactor logging a tiny bit so that `myloader` can have a `logfile <logfile>` option.

This should address an earlier [issue](https://github.com/maxbube/mydumper/issues/230) I noticed a few days ago.