### PR TITLE
Adding commit_count > 1

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -545,7 +545,7 @@ void restore_data(MYSQL *conn, char *database, char *table,
     g_free(query);
   }
 
-  if (!is_schema)
+  if (!is_schema && (commit_count > 1) )
     mysql_query(conn, "START TRANSACTION");
 
   while (eof == FALSE) {
@@ -559,7 +559,7 @@ void restore_data(MYSQL *conn, char *database, char *table,
           return;
         }
         query_counter++;
-        if (!is_schema && (query_counter == commit_count)) {
+        if (!is_schema && (commit_count > 1) && (query_counter == commit_count)) {
           query_counter = 0;
           if (mysql_query(conn, "COMMIT")) {
             g_critical("Error committing data for %s.%s: %s",

--- a/myloader.c
+++ b/myloader.c
@@ -578,7 +578,7 @@ void restore_data(MYSQL *conn, char *database, char *table,
       return;
     }
   }
-  if (!is_schema && mysql_query(conn, "COMMIT")) {
+  if (!is_schema && (commit_count > 1) && mysql_query(conn, "COMMIT")) {
     g_critical("Error committing data for %s.%s from file %s: %s",
                db ? db : database, table, filename, mysql_error(conn));
     errors++;

--- a/myloader.c
+++ b/myloader.c
@@ -464,7 +464,8 @@ void *process_queue(struct thread_data *td) {
   mysql_query(thrconn, "/*!40101 SET NAMES binary*/");
   mysql_query(thrconn, "/*!40101 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */");
   mysql_query(thrconn, "/*!40014 SET UNIQUE_CHECKS=0 */");
-  mysql_query(thrconn, "SET autocommit=0");
+  if (commit_count > 1)
+    mysql_query(thrconn, "SET autocommit=0");
 
   g_async_queue_push(conf->ready, GINT_TO_POINTER(1));
 


### PR DESCRIPTION
If we add commit_count > 1 we are avoiding to send to the database the START TRANSACTION and COMMIT statements, this is desirable in some scenarios