### PR TITLE
Adding file name to the log during restoring data for better logging

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -535,8 +535,8 @@ void restore_data(MYSQL *conn, char *database, char *table,
     gchar *query = g_strdup_printf("USE `%s`", db ? db : database);
 
     if (mysql_query(conn, query)) {
-      g_critical("Error switching to database %s whilst restoring table %s",
-                 db ? db : database, table);
+      g_critical("Error switching to database %s whilst restoring table %s from file %s",
+                 db ? db : database, table, filename);
       g_free(query);
       errors++;
       return;
@@ -562,8 +562,8 @@ void restore_data(MYSQL *conn, char *database, char *table,
         if (!is_schema && (query_counter == commit_count)) {
           query_counter = 0;
           if (mysql_query(conn, "COMMIT")) {
-            g_critical("Error committing data for %s.%s: %s",
-                       db ? db : database, table, mysql_error(conn));
+            g_critical("Error committing data for %s.%s: from file %s: %s",
+                       db ? db : database, table, filename, mysql_error(conn));
             errors++;
             return;
           }


### PR DESCRIPTION
As of version 0.9.5, when we throw error during the data restoration, we neither specify the thread which caused the error nor we specify the file which produced this error. Due to this, the consumer could not build a utility to find out all the files which could not be restored and thus has no option other than fully restore the db table again. 

This become worse when the chunk size in myDumper and no. of query per transaction in myloader are same and even though he/she cannot retry those files which failed due to connection issues or other temporary glitches and thus could not be restored even when the table was in stable state.