### PR TITLE
Fix warnings in sphinx document generation

### DIFF
--- a/docs/_build/conf.py.in
+++ b/docs/_build/conf.py.in
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_static']
+html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/html/_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/_build/conf.py.in
+++ b/docs/_build/conf.py.in
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_static']
+#html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/files.rst
+++ b/docs/files.rst
@@ -36,7 +36,7 @@ Where 'chunk' is a number padded with up to 5 zeros.
 
 Table Schemas
 -------------
-When the :option:`--schemas <mydumper --schemas>` option is used mydumper will
+As long as the :option:`--no-schemas <mydumper --no-schemas>` option is not specified, mydumper will
 create a file for the schema of every table it is writing data for.  The files
 for this are in the following format::
 


### PR DESCRIPTION
Fix warnings in sphinx document generation caused by non-existing directories and removed options
Fixes #252 