### PR TITLE
Simpler if condition for purge-mode

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -471,7 +471,9 @@ void add_schema(const gchar *filename, MYSQL *conn) {
 
   g_free(query);
 
-  if (purge_mode == DROP || purge_mode == NONE || (truncate_or_delete_failed && (purge_mode == TRUNCATE || purge_mode == DELETE ))){
+  if ((purge_mode == TRUNCATE || purge_mode == DELETE) && !truncate_or_delete_failed){
+      g_message("Skipping table creation `%s`.`%s`", db ? db : database, table);
+  }else{
     g_message("Creating table `%s`.`%s`", db ? db : database, table);
     restore_data(conn, database, table, filename, TRUE, TRUE);
   }


### PR DESCRIPTION
I have realized that just when the table is in TRUNCATE or DELETE, the create table should be skipped and just when those have failed, we should be creating the table. 