### PR TITLE
Fix issues when daemon is used on glist

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1881,6 +1881,7 @@ void start_dump(MYSQL *conn) {
     dump_table(conn, dbt->database, dbt->table, &conf, TRUE);
   }
   g_list_free(innodb_tables);
+  innodb_tables=NULL;
 
   table_schemas = g_list_reverse(table_schemas);
   for (iter = table_schemas; iter != NULL; iter = iter->next) {
@@ -1891,6 +1892,7 @@ void start_dump(MYSQL *conn) {
     g_free(dbt);
   }
   g_list_free(table_schemas);
+  table_schemas=NULL;
 
   view_schemas = g_list_reverse(view_schemas);
   for (iter = view_schemas; iter != NULL; iter = iter->next) {
@@ -1901,6 +1903,7 @@ void start_dump(MYSQL *conn) {
     g_free(dbt);
   }
   g_list_free(view_schemas);
+  view_schemas=NULL;
 
   schema_post = g_list_reverse(schema_post);
   for (iter = schema_post; iter != NULL; iter = iter->next) {
@@ -1910,6 +1913,7 @@ void start_dump(MYSQL *conn) {
     g_free(sp);
   }
   g_list_free(schema_post);
+  schema_post=NULL;
 
   if (!no_locks && !trx_consistency_only) {
     g_async_queue_pop(conf.unlock_tables);


### PR DESCRIPTION
I found that using daemon, on the second iteration, we ended up with stuff like this:
```
** Message: 10:57:02.551: Thread 1 connected using MySQL connection ID 85
** Message: 10:57:02.556: Thread 2 connected using MySQL connection ID 86
** Message: 10:57:02.560: Thread 3 connected using MySQL connection ID 87
** Message: 10:57:02.566: Thread 4 connected using MySQL connection ID 88
** Message: 10:57:02.566: Thread 1 dumping db information for `viasat`
** Message: 10:57:02.566: Thread 2 dumping schema create for `viasat`
free(): invalid pointer
** Message: 10:57:02.567: Thread 3 dumping data for ``\x8d\u0004\xac\u001a\u007f`.`(null)`
** Message: 10:57:02.567: Thread 4 dumping data for `viasat`.`sat_msgPos`
```
That is because the list was set to freed but the pointer in the variable was not reseted. 