### PR TITLE
fixing allowed in C99 mode error

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1093,7 +1093,8 @@ int main(int argc, char *argv[]) {
   g_option_context_free(context);
 
   if (password != NULL){
-    for(int i=1; i < argc; i++){
+    int i=1;	  
+    for(i=1; i < argc; i++){
       gchar * p= g_strstr_len(argv[i],-1,password);
       if (p != NULL){
         strncpy(p, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", strlen(password));


### PR DESCRIPTION
This is to avoid this error when compiling:
```
/tmp/mydumper/mydumper.c:1096:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for(int i=1; i < argc; i++){
```