### PR TITLE
Moving detected_generated_fields as parameter in table_job

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -3568,8 +3568,8 @@ guint64 dump_table_data(MYSQL *conn, FILE *file, struct table_job *tj) {
       "SELECT %s %s FROM `%s`.`%s` %s %s %s %s",
       (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */" : "",
       select_fields->str, database, table, where ? "WHERE" : "",
-      where ? where : "", order_by ? "ORDER BY" : "",
-      order_by ? order_by : "");
+      where ? where : "", tj->order_by ? "ORDER BY" : "",
+      tj->order_by ? tj->order_by : "");
   g_string_free(select_fields, TRUE);
   if (mysql_query(conn, query) || !(result = mysql_use_result(conn))) {
     // ERROR 1146

--- a/mydumper.h
+++ b/mydumper.h
@@ -65,6 +65,7 @@ struct table_job {
   char *table;
   char *filename;
   char *where;
+  gboolean has_generated_fields;
 };
 
 struct tables_job {


### PR DESCRIPTION
Moving detected_generated_fields as parameter in table_job to avoid extra calls during dumping