### PR TITLE
Adding sync mechanism and constraint split

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -793,10 +793,12 @@ void *process_queue(struct thread_data *td) {
           dbt->current_threads--;
           dbt->start_index_time=g_date_time_new_now_local();
           g_mutex_unlock(dbt->mutex);
-          g_message("Thread %d restoring indexes `%s`.`%s`", td->thread_id,
+	  if (dbt->indexes != NULL) {
+            g_message("Thread %d restoring indexes `%s`.`%s`", td->thread_id,
                   dbt->database, dbt->table);
-          guint query_counter=0;
-          restore_data_in_gstring(thrconn, dbt->database, dbt->table, dbt->indexes, NULL, FALSE, &query_counter);
+            guint query_counter=0;
+            restore_data_in_gstring(thrconn, dbt->database, dbt->table, dbt->indexes, NULL, FALSE, &query_counter);
+	  }
           dbt->finish_time=g_date_time_new_now_local();
         }else{
           g_mutex_unlock(dbt->mutex);

--- a/myloader.c
+++ b/myloader.c
@@ -350,11 +350,13 @@ int main(int argc, char *argv[]) {
   }
 
   GList * t=conf.table_list;
+  g_message("Import timings:");
+  g_message("Data      \t| Index    \t| Total   \t| Table");
   while (t != NULL){
     struct db_table * dbt=t->data;
     GTimeSpan diff1=g_date_time_difference(dbt->start_index_time,dbt->start_time);
     GTimeSpan diff2=g_date_time_difference(dbt->finish_time,dbt->start_index_time);
-    g_message("Import timings for `%s`.`%s`: Data: %s | Index: %s | Time: %s",dbt->database,dbt->table, print_time(diff1),print_time(diff2),print_time(diff1+diff2));
+    g_message("%s\t| %s\t| %s\t| `%s`.`%s`",print_time(diff1),print_time(diff2),print_time(diff1+diff2),dbt->database,dbt->table);
     t=t->next;
   }
 

--- a/myloader.c
+++ b/myloader.c
@@ -365,7 +365,7 @@ int main(int argc, char *argv[]) {
     g_message("%s\t| %s\t| %s\t| `%s`.`%s`",print_time(diff1),print_time(diff2),print_time(diff1+diff2),dbt->database,dbt->table);
     t=t->next;
   }
-
+  innodb_optimize_keys=FALSE;
   g_async_queue_unref(conf.ready);
 
   restore_schema_post(conn);
@@ -986,7 +986,7 @@ void restore_data_from_file(MYSQL *conn, char *database, char *table,
 
             // Check if it is a /*!40  SET 
 	    if (g_strrstr(data->str,"/*!40")){
-          g_string_append(alter_table_statement,data->str);
+              g_string_append(alter_table_statement,data->str);
 	      restore_data_in_gstring_from_file(conn, database, table, data, filename, is_schema, &query_counter);
 	    }else{
               // Processing CREATE TABLE statement

--- a/myloader.c
+++ b/myloader.c
@@ -685,12 +685,17 @@ void *process_queue(struct thread_data *td) {
 
   g_async_queue_push(conf->ready, GINT_TO_POINTER(1));
   GList *table_list=conf->table_list;
-  struct db_table *dbt=table_list->data;
-  g_mutex_lock(dbt->mutex);
-  dbt->current_threads++;
-  if (dbt->start_time==NULL)
-    dbt->start_time=g_date_time_new_now_local();
-  g_mutex_unlock(dbt->mutex);
+  struct db_table *dbt=NULL;
+  if (table_list == NULL ) {
+    dbt=NULL;
+  }else{
+    dbt=table_list->data;
+    g_mutex_lock(dbt->mutex);
+    dbt->current_threads++;
+    if (dbt->start_time==NULL)
+      dbt->start_time=g_date_time_new_now_local();
+    g_mutex_unlock(dbt->mutex);
+  }
   struct job *job = NULL;
   struct restore_job *rj = NULL;
   for (;;) {

--- a/myloader.c
+++ b/myloader.c
@@ -605,8 +605,8 @@ void *process_queue(struct thread_data *td) {
     switch (job->type) {
     case JOB_RESTORE_STRING:
       rj = job->job_data;
-      g_message("Thread %d restoring indexes or contraints `%s`.`%s` %s", td->thread_id,
-                rj->database, rj->table, rj->statement->str);
+      g_message("Thread %d restoring indexes or contraints `%s`.`%s`", td->thread_id,
+                rj->database, rj->table);
       guint query_counter=0;
       //restore_data_in_gstring(thrconn, rj->database, rj->table, rj->prestatement, NULL, FALSE, &query_counter);
       restore_data_in_gstring(thrconn, rj->database, rj->table, rj->statement, NULL, FALSE, &query_counter);

--- a/myloader.h
+++ b/myloader.h
@@ -27,8 +27,8 @@ enum purge_mode { NONE, DROP, TRUNCATE, DELETE };
 struct configuration {
   GAsyncQueue *queue;
   GAsyncQueue *ready;
-  GAsyncQueue *fast_index_creation_queue;
   GAsyncQueue *constraints_queue;
+  GList *table_list;
   GMutex *mutex;
   int done;
 };
@@ -52,4 +52,18 @@ struct restore_job {
   guint part;
 };
 
+struct db_table {
+  char *database;
+  char *table;
+  guint64 rows;
+  GAsyncQueue * queue;
+  guint current_threads;
+  guint max_threads;
+  GMutex *mutex;
+  GString *indexes;
+  guint count;
+  GDateTime * start_time;
+  GDateTime * start_index_time;
+  GDateTime * finish_time;
+};
 #endif

--- a/myloader.h
+++ b/myloader.h
@@ -28,6 +28,7 @@ struct configuration {
   GAsyncQueue *queue;
   GAsyncQueue *ready;
   GAsyncQueue *fast_index_creation_queue;
+  GAsyncQueue *constraints_queue;
   GMutex *mutex;
   int done;
 };


### PR DESCRIPTION
After implementing Fast Index Creation, @bato3 reported an issue related to constraints. Before adding a constraints we need to be sure that there is an index over the referenced column. That is why we had to split the add index step in 2 stages, first the indexes and then the constraints. 
We also find out that the sync mechanism was not correctly implemented. Now is more robust.