### PR TITLE
Adding libatomic1 dependency reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ yum install https://github.com/maxbube/mydumper/releases/download/v0.10.5/mydump
 ```
 
 ### Ubuntu / Debian
-
+For ubuntu, you need to install the dependencies:
+```bash
+apt-get intall libatomic1
+```
+Then you can download and install the package:
 ```bash
 wget https://github.com/maxbube/mydumper/releases/download/v0.10.5/mydumper_0.10.5-1.$(lsb_release -cs)_amd64.deb
 dpkg -i mydumper_0.10.5-1.$(lsb_release -cs)_amd64.deb


### PR DESCRIPTION
We need to mention in the documentation that after https://github.com/maxbube/mydumper/issues/222 libatomic1 is required for deb installations.