### PR TITLE
Avoid logging SQL data on error

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -901,7 +901,7 @@ void restore_data_in_gstring_from_file(MYSQL *conn, char *database, char *table,
 {
                 if (mysql_real_query(conn, data->str, data->len)) {
 
-                        g_critical("Error restoring %s.%s from file %s: %s \n%s", db ? db : database, table, filename, mysql_error(conn),data->str);
+                        g_critical("Error restoring %s.%s from file %s: %s \n", db ? db : database, table, filename, mysql_error(conn));
                         errors++;
                         return;
                 }


### PR DESCRIPTION
The deleted code logs the contents of the SQL INSERT request when the mysql query failed.

Since this content could come from any table, it can both generate high amounts of logs and potentially leak sensitive content, so I think this should not be logged at all :slightly_smiling_face: 