### PR TITLE
needs to notify main thread to go ahead when "--tables-list" is used without "-B"!

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -2861,6 +2861,7 @@ void get_tables(MYSQL *conn, struct configuration *conf) {
       }
     }
   }
+  g_async_queue_pop(conf.ready_database_dump);  // needs to notify main thread to go ahead when "--tables-list" is used without "-B"!
   g_free(query);
 }
 


### PR DESCRIPTION
needs to notify main thread to go ahead when "--tables-list" is used without "-B"!
otherwise main thread is blocked and just wait.