### PR TITLE
Adding LC_ALL to allow multi-byte parameters

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -55,6 +55,7 @@
 #include "getPassword.h"
 #include "logging.h"
 #include "set_verbose.h"
+# include "locale.h"
 
 char *regexstring = NULL;
 
@@ -1116,6 +1117,7 @@ int main(int argc, char *argv[]) {
   GOptionContext *context;
 
   g_thread_init(NULL);
+  setlocale(LC_ALL, "");
 
   ref_table_mutex = g_mutex_new();
   init_mutex = g_mutex_new();

--- a/myloader.c
+++ b/myloader.c
@@ -40,6 +40,7 @@
 #include "getPassword.h"
 #include "logging.h"
 #include "set_verbose.h"
+# include "locale.h"
 
 guint commit_count = 1000;
 gchar *directory = NULL;
@@ -237,6 +238,7 @@ int main(int argc, char *argv[]) {
   GError *error = NULL;
   GOptionContext *context;
 
+  setlocale(LC_ALL, "");
   g_thread_init(NULL);
 
   init_mutex = g_mutex_new();


### PR DESCRIPTION
This fixes the bug reported in the linked issues.